### PR TITLE
[Feat] ocr 추출 값 가공 및 work() 수정

### DIFF
--- a/project/apps/ocr/serializers.py
+++ b/project/apps/ocr/serializers.py
@@ -133,10 +133,13 @@ class OcrImageSerializer(serializers.Serializer):
                     for img in data.get("images", []) or []
                     for field in img.get("fields", []) or []
                 ]
+                texts = [t for t in texts if t]
+
                 return idx, {
                     "file": name,
-                    "texts": [t for t in texts if t],
-                    "raw": data,
+                    "texts": texts,                      # ★ TaskLLMView가 기대하는 키
+                    "full_text": " ".join(texts),        # (선택) 한 줄로 합친 텍스트 - 디버그/로그용
+                    # "raw": data,                       # (선택) 필요시 주석 해제
                 }
             except requests.RequestException as e:
                 return idx, {


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #31

### ✨️ 작업 내용

현재 ocr 추출 값이 텍스트 단위로 잘리는 문제가 있었는데, 이를 Text 변수에 문장으로 담아서 llm로 보내게 수정했습니다.
또한 llm 처리 과정 중 일부인 ocr 전처리 단계에서 ocr/serializers.py의 work() 반환 값과 타입이 맞지 않는 문제를 발견해, work()에서 리스트 형식으로 반환하게끔 수정했습니다.

### 💭 코멘트

X

### 📸 구현 결과

- ocr -> llm 거칠 이미지
<img width="342" height="460" alt="Image" src="https://github.com/user-attachments/assets/ea8d89b6-a37e-4bb2-8c4b-aea8e6135808" />


- task/process 결과 값
<img width="2272" height="1306" alt="Image" src="https://github.com/user-attachments/assets/c40e7c63-3592-4861-8d3d-5e347d3948f8" />