### PR TITLE
✨ tag_calendar 필드 필수 제외 (#28)

### DIFF
--- a/project/apps/calendars/serializers.py
+++ b/project/apps/calendars/serializers.py
@@ -8,7 +8,7 @@ from external.time_manager import KST
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        fields = '__all__'
+        exclude = ('calendar',)
 
 class TagCreateSerializer(serializers.ModelSerializer):    
     class Meta:
@@ -26,7 +26,7 @@ class TagCreateSerializer(serializers.ModelSerializer):
 class TagUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        exclude = ('id', 'calendar',)
+        exclude = ('id', 'calendar')
 
     def update(self, instance, validated_data):        
         for attr, value in validated_data.items():


### PR DESCRIPTION
### 📑 이슈 번호

- close #28 

### ✨️ 작업 내용

일정 등록 시 tag 내 calendar를 필수로 받는 문제 해결했습니다

### 📸 구현 결과

1. calendar 값 없이 태그 id 16 등록
<img width="1343" height="885" alt="스크린샷 2025-11-09 235755" src="https://github.com/user-attachments/assets/d0db608c-09d7-4cfd-8ab1-40067b481694" />

2. 같은 태그 등록 시 id 변동 없음을 확인
<img width="1369" height="883" alt="스크린샷 2025-11-09 235814" src="https://github.com/user-attachments/assets/2d9f83ba-efbe-4d7d-9602-f2e53088d13a" />

3. 구글 연동 깨짐없이 반영 제목 string은 게스트 상태에서 반영한 것, string 2, string 3은 연동 후 넣은 것!
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/e96a75fa-562c-485b-bd2e-e2600e5b3a51" />

