### PR TITLE
[Feat] 이미지 DB 저장 및 일정 등록 시 task 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ project/security/*.json
 project/.env
 
 project/static/*
+
+project/tasks
+project/task_images

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ project/.env
 
 project/static/*
 
-project/tasks
 project/task_images

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ project/.env
 
 project/static/*
 
-project/task_images
+project/media

--- a/project/apps/calendars/serializers.py
+++ b/project/apps/calendars/serializers.py
@@ -1,4 +1,6 @@
+from apps.tasks.models import Task
 from .models import Schedule, Tag
+from apps.tasks.seriallizers import ImageSerializer
 from rest_framework import serializers
 
 from django.utils.dateparse import parse_datetime
@@ -37,9 +39,26 @@ class TagUpdateSerializer(serializers.ModelSerializer):
 
 class ScheduleSerializer(serializers.ModelSerializer):
     tag = TagSerializer(required=False)
+    images = serializers.SerializerMethodField()
     class Meta:
         model = Schedule
         fields = '__all__'
+
+    # 이미지 url 리스트 반환
+    def get_images(self, obj):
+        request = self.context.get('request')
+        urls = []
+
+        for img in obj.images.all():
+            if img.task_image:
+                # 절대 URL로 변환
+                if request is not None:
+                    url = request.build_absolute_uri(img.task_image.url)
+                else:
+                    url = img.task_image.url
+                urls.append(url)
+
+        return urls
         
 
     # 공통 태그 처리 로직
@@ -57,6 +76,7 @@ class ScheduleSerializer(serializers.ModelSerializer):
 
 class ScheduleCreateSerializer(ScheduleSerializer): 
 
+    task_id = serializers.IntegerField(required=False, allow_null=True)
     class Meta:
         model = Schedule
         exclude = ('id', 'calendar', 'created_at', 'updated_at')
@@ -67,12 +87,21 @@ class ScheduleCreateSerializer(ScheduleSerializer):
     def create(self, validated_data):
         user = self.context['request'].user
         tag_data = validated_data.pop("tag", None)
+        task_id = validated_data.pop("task_id", None)
         schedule = Schedule.objects.create(
             calendar=user.calendar,
             **validated_data
         )
 
         self._handle_tag(schedule, tag_data, user.calendar)
+
+        if task_id:
+            try:
+                task = Task.objects.get(id=task_id)
+                task.images.update(schedule=schedule)
+            except Task.DoesNotExist:
+                print(f"Task {task_id} 가 없어 일정 연결을 하지 않고 넘어갑니다.")
+                
         return schedule
     
 class ScheduleUpdateSerializer(ScheduleSerializer):

--- a/project/apps/ocr/serializers.py
+++ b/project/apps/ocr/serializers.py
@@ -7,6 +7,10 @@ import concurrent.futures
 from rest_framework import serializers
 from django.conf import settings
 
+from apps.tasks.models import Image, Task
+from apps.calendars.models import Schedule
+from django.db import transaction
+
 # MIME → 확장자 매핑
 MIME_EXT = {
     "image/jpeg": "jpg",
@@ -97,6 +101,7 @@ class OcrImageSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         files = validated_data["images"]
+        user = self.context["request"].user
 
         api_url = getattr(settings, "CLOVA_OCR_URL", None)
         secret  = getattr(settings, "CLOVA_OCR_SECRET", None)
@@ -105,13 +110,24 @@ class OcrImageSerializer(serializers.Serializer):
 
         headers = _clova_headers(secret)
 
-        # 파일 → (index, name, fmt, b64) 전처리 (I/O는 메인 스레드에서)
-        items = []
-        for idx, f in enumerate(files):
-            name = getattr(f, "name", f"image_{idx+1}.jpg")
-            fmt  = _ext_from_file(f)
-            b64  = _b64_from_file(f)
-            items.append((idx, name, fmt, b64))
+        # 하나의 Task를 만들어서 이미지들을 묶어줌 (optional)
+        with transaction.atomic():
+            task = Task.objects.create()
+
+            items = []
+            for idx, f in enumerate (files):
+                # 1) 이미지 저장 (유저, Task 연결)
+                img_instance = Image.objects.create(
+                    task=task,
+                    task_image=f,
+                )
+
+                # 2) 파일 형태에 따른 전처리
+                # 파일 → (index, name, fmt, b64) 전처리 (I/O는 메인 스레드에서)
+                name = getattr(f, "name", f"image_{idx+1}.jpg")
+                fmt  = _ext_from_file(f)
+                b64  = _b64_from_file(f)
+                items.append((idx, name, fmt, b64))
 
         results = [None] * len(items)
 
@@ -153,4 +169,4 @@ class OcrImageSerializer(serializers.Serializer):
             for idx, res in ex.map(work, items):
                 results[idx] = res
 
-        return {"results": results}
+        return {"task_id": task.id, "results": results}

--- a/project/apps/ocr/views.py
+++ b/project/apps/ocr/views.py
@@ -24,7 +24,7 @@ class OcrView(APIView):
             )
 
         # 2) 직렬화/검증
-        serializer = OcrImageSerializer(data={"images": files})
+        serializer = OcrImageSerializer(data={"images": files}, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
         # 3) 처리 (serializer.create 내부에서 CLOVA 병렬 호출)

--- a/project/apps/tasks/models.py
+++ b/project/apps/tasks/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from apps.calendars.models import Schedule
 
 def image_upload_path(instance: 'Image', filename: str) -> str:
-    return f"tasks/{instance.task.id}/{filename}"
+    return f"task_images/{instance.task.id}/{filename}"
 
 class Task(models.Model):
 		id = models.AutoField(primary_key=True)

--- a/project/apps/tasks/seriallizers.py
+++ b/project/apps/tasks/seriallizers.py
@@ -18,3 +18,8 @@ class TaskSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = ["id", "ocr_result", "llm_result"]
+
+class ImageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Image
+        fields = ['id', 'task_image']

--- a/project/apps/tasks/urls.py
+++ b/project/apps/tasks/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 
-from django.conf import settings
-from django.conf.urls.static import static
+# from django.conf import settings
+# from django.conf.urls.static import static
 
 from rest_framework.routers import DefaultRouter
 from .views import *
@@ -9,11 +9,8 @@ from .views import *
 
 app_name = "tasks"
 
-# router = DefaultRouter(trailing_slash=False)
-# router.register('', TaskViewSet, basename='task')
-
 urlpatterns = [
   # path('', include(router.urls)),
   path("process/", TaskLLMView.as_view()),
 
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+]

--- a/project/apps/tasks/views.py
+++ b/project/apps/tasks/views.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from apps.users.services import JWTAuthentication
 from apps.ocr.views import OcrView
+from apps.tasks.models import Task
 
 from .services import create_schedule, parse_response, recommend_time, refine_ocr
 
@@ -19,8 +20,9 @@ class TaskLLMView(OcrView):
 
         # 1) 이미지 업로드 ->  ocr 처리 수행
         ocr_response = super().post(request, *args, **kwargs)
-        print("ocr_responses:", ocr_response)
+        
         ocr_results = ocr_response.data.get("results", [])
+        task_id = ocr_response.data.get("task_id")
         if not ocr_results:
             return Response(
                 {"error": "OCR 결과가 없습니다."},
@@ -98,8 +100,18 @@ class TaskLLMView(OcrView):
             except json.JSONDecodeError:
                 print("Response용 OCR 파싱 실패, 원본 유지")
 
+        # 5) task 모델 업데이트
+        if task_id:
+            try:
+                task = Task.objects.get(id=task_id)
+                task.ocr_result = "\n".join(all_texts)
+                task.llm_result = json.dumps(results, ensure_ascii=False)
+                task.save(update_fields=["ocr_result", "llm_result"])
+            except Task.DoesNotExist:
+                print(f"Task {task_id}가 없어 저장에 실패했습니다.")
+
 
         return Response(
-            {"ocr_result": parsed_ocr, "llm_result": results, "recommendation": recommends},
+            {"task_id": task_id, "ocr_result": parsed_ocr, "llm_result": results, "recommendation": recommends},
             status=status.HTTP_200_OK,
         )

--- a/project/apps/tasks/views.py
+++ b/project/apps/tasks/views.py
@@ -19,7 +19,7 @@ class TaskLLMView(OcrView):
 
         # 1) 이미지 업로드 ->  ocr 처리 수행
         ocr_response = super().post(request, *args, **kwargs)
-
+        print("ocr_responses:", ocr_response)
         ocr_results = ocr_response.data.get("results", [])
         if not ocr_results:
             return Response(

--- a/project/scandy/settings.py
+++ b/project/scandy/settings.py
@@ -257,3 +257,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CLOVA_OCR_URL = env("CLOVA_OCR_URL")
 CLOVA_OCR_SECRET = env("CLOVA_OCR_SECRET")
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/project/scandy/urls.py
+++ b/project/scandy/urls.py
@@ -17,6 +17,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from drf_spectacular.views import SpectacularJSONAPIView, SpectacularRedocView, SpectacularSwaggerView
+from django.conf import settings
+from django.conf.urls.static import static
 
 
 urlpatterns = [
@@ -33,3 +35,6 @@ urlpatterns = [
     path('api/redoc/', SpectacularRedocView.as_view(url_name='schema-json'), name='redoc'),
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema-json"), name="swagger-ui"),
 ]
+
+if settings.DEBUG:  # 로컬에서만
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
### 📑 이슈 번호

- close #

### ✨️ 작업 내용
task/process/ 처리 시 업로드한 이미지를 DB에 저장 
일정 등록 시 task 연결

### 📸 구현 결과
1. llm 일정 해석 => task 생성
<img width="969" height="879" alt="스크린샷 2025-11-11 153350" src="https://github.com/user-attachments/assets/f6d2a921-be53-474b-a16b-f637b9d280da" />

2. 일정 등록 + task_id 포함
<img width="1039" height="878" alt="스크린샷 2025-11-11 153415" src="https://github.com/user-attachments/assets/f2f16c77-cf2a-429e-8ec5-0ebf9db0d5fb" />

3. 일정 조회 시 이미지 링크 반환
<img width="1095" height="872" alt="스크린샷 2025-11-11 153442" src="https://github.com/user-attachments/assets/b077b1ea-9ca3-4091-9d98-efc5a0cfe053" />

